### PR TITLE
Remove auto-scroll effect from ChatMessages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,3 @@ coverage
 
 *storybook.log
 storybook-static
-/.github

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ coverage
 
 *storybook.log
 storybook-static
+/.github

--- a/src/components/Chat/ChatContent/ChatMessages/ChatMessages.tsx
+++ b/src/components/Chat/ChatContent/ChatMessages/ChatMessages.tsx
@@ -1,5 +1,3 @@
-import { useRef } from 'react'
-
 import useChatStore from '@/stores/useChatStore'
 
 import ChatMessage from './ChatMessage/ChatMessage'
@@ -9,15 +7,12 @@ export default function ChatMessages() {
   const messages = useChatStore(state => state.messages)
   const waitingForReply = useChatStore(state => state.waitingForReply)
 
-  const messagesEndRef = useRef<HTMLDivElement>(null)
-
   return (
     <div className="flex-1 pt-4 px-4 space-y-4 overflow-y-auto" tabIndex={0}>
       {messages.map(message => (
         <ChatMessage key={message.id} {...message} />
       ))}
       {waitingForReply && <ChatMessage role={MessageRole.Assistant} content="" progress />}
-      <div ref={messagesEndRef} className="h-4" />
     </div>
   )
 }

--- a/src/components/Chat/ChatContent/ChatMessages/ChatMessages.tsx
+++ b/src/components/Chat/ChatContent/ChatMessages/ChatMessages.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useRef } from 'react'
 
 import useChatStore from '@/stores/useChatStore'
 
@@ -10,14 +10,6 @@ export default function ChatMessages() {
   const waitingForReply = useChatStore(state => state.waitingForReply)
 
   const messagesEndRef = useRef<HTMLDivElement>(null)
-
-  const scrollToBottom = (behavior: 'smooth' | 'instant' = 'smooth') => {
-    messagesEndRef.current?.scrollIntoView({ behavior })
-  }
-
-  useEffect(() => {
-    scrollToBottom('instant')
-  }, [messages])
 
   return (
     <div className="flex-1 pt-4 px-4 space-y-4 overflow-y-auto" tabIndex={0}>


### PR DESCRIPTION
Eliminated the useEffect and scrollToBottom logic that automatically scrolled to the bottom of the chat messages when messages changed. Also updated .gitignore to exclude the /.github directory.