### PR TITLE
Open links in ChatMessage markdown in new tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,3 @@ coverage
 
 *storybook.log
 storybook-static
-/.github

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ coverage
 
 *storybook.log
 storybook-static
+/.github

--- a/src/components/Chat/ChatContent/ChatMessages/ChatMessage/ChatMessage.stories.tsx
+++ b/src/components/Chat/ChatContent/ChatMessages/ChatMessage/ChatMessage.stories.tsx
@@ -88,6 +88,23 @@ console.log("Hello, world!");
   },
 }
 
+export const MarkdownWithLinks: Story = {
+  args: {
+    role: MessageRole.Assistant,
+    content: `
+Here are some useful links:
+
+- [OpenAI Documentation](https://platform.openai.com/docs)
+- [React Documentation](https://react.dev)
+- [Tailwind CSS](https://tailwindcss.com)
+
+You can also visit https://github.com for more resources.
+
+Check out this [inline link](https://example.com) in the middle of text.
+    `,
+  },
+}
+
 export const ErrorMessage: Story = {
   args: {
     role: MessageRole.User,

--- a/src/components/Chat/ChatContent/ChatMessages/ChatMessage/ChatMessage.tsx
+++ b/src/components/Chat/ChatContent/ChatMessages/ChatMessage/ChatMessage.tsx
@@ -37,7 +37,22 @@ function ChatMessage({ role, content, progress, error }: ChatMessageProps) {
             className={`max-w-full rounded-lg ${role === MessageRole.User ? 'p-3 bg-muted' : ''}`}
           >
             {role === MessageRole.Assistant ? (
-              <Markdown className="text-sm prose">{content}</Markdown>
+              <Markdown
+                className="text-sm prose"
+                options={{
+                  overrides: {
+                    a: {
+                      props: {
+                        target: '_blank',
+                        rel: 'noopener noreferrer',
+                        className: 'underline hover:text-blue-600 transition-colors',
+                      },
+                    },
+                  },
+                }}
+              >
+                {content}
+              </Markdown>
             ) : (
               <p className="text-sm whitespace-pre-wrap">{content}</p>
             )}


### PR DESCRIPTION
Updated the ChatMessage component to render markdown links with target="_blank" and rel="noopener noreferrer" for security and usability. Added a new Storybook story to demonstrate markdown with various links.