### PR TITLE
Add prompt library feature

### DIFF
--- a/@/components/ui/dialog.tsx
+++ b/@/components/ui/dialog.tsx
@@ -1,0 +1,141 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/utils/ui"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/@/components/ui/popover.tsx
+++ b/@/components/ui/popover.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+
+import { cn } from "@/utils/ui"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.7",
+        "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-toggle": "^1.1.10",
@@ -2079,6 +2081,42 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
@@ -2186,6 +2224,43 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "postinstall": "wxt prepare"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-toggle": "^1.1.10",

--- a/src/components/Chat/ChatInput/ChatInput.tsx
+++ b/src/components/Chat/ChatInput/ChatInput.tsx
@@ -1,16 +1,18 @@
-import { ArrowUp, Square, Zap } from 'lucide-react'
+import { ArrowUp, Square, Zap, BookText } from 'lucide-react'
 import { memo, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { Toggle } from '@/components/ui/toggle'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import ContextDisplay from '@/components/Chat/ContextDisplay/ContextDisplay'
 import useChatStore from '@/stores/useChatStore'
 import ModelSelect from '@/components/Chat/ModelSelect/ModelSelect'
 
 function ChatInput() {
   const [input, setInput] = useState('')
+  const [promptPopoverOpen, setPromptPopoverOpen] = useState(false)
   const formRef = useRef<HTMLFormElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
@@ -23,6 +25,7 @@ function ChatInput() {
 
   const autoExecuteTools = useChatStore(state => state.settings.data?.autoExecuteTools)
   const updateSettings = useChatStore(state => state.updateSettings)
+  const prompts = useChatStore(state => state.settings.data?.prompts || [])
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
@@ -46,6 +49,12 @@ function ChatInput() {
     stopMessage()
   }
 
+  const handlePromptSelect = (promptContent: string) => {
+    setInput(promptContent)
+    setPromptPopoverOpen(false)
+    textareaRef.current?.focus()
+  }
+
   return (
     <div className="rounded-t-xl bg-card">
       <div className="flex justify-start m-2">
@@ -67,6 +76,45 @@ function ChatInput() {
           <ModelSelect />
           <div className="flex items-center gap-2 ml-auto">
             <TooltipProvider>
+              {prompts.length > 0 && (
+                <Popover open={promptPopoverOpen} onOpenChange={setPromptPopoverOpen}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <PopoverTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          aria-label="Select prompt template"
+                          className="size-8"
+                        >
+                          <BookText className="size-4" />
+                        </Button>
+                      </PopoverTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>{'Prompt templates'}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                  <PopoverContent className="w-80 p-2" align="end">
+                    <div className="space-y-1">
+                      <div className="text-sm font-medium px-2 py-1.5">Prompt Templates</div>
+                      {prompts.map(prompt => (
+                        <button
+                          key={prompt.id}
+                          onClick={() => handlePromptSelect(prompt.content)}
+                          className="w-full text-left px-2 py-2 rounded-md hover:bg-accent transition-colors"
+                        >
+                          <div className="font-medium text-sm">{prompt.title}</div>
+                          <div className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
+                            {prompt.content}
+                          </div>
+                        </button>
+                      ))}
+                    </div>
+                  </PopoverContent>
+                </Popover>
+              )}
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Toggle

--- a/src/components/PromptLibrary/PromptLibrary.tsx
+++ b/src/components/PromptLibrary/PromptLibrary.tsx
@@ -1,0 +1,178 @@
+import { Pencil, Trash2, Plus } from 'lucide-react'
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import useChatStore from '@/stores/useChatStore'
+import type { Prompt } from '@/types/settings.types'
+
+type PromptDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  prompt?: Prompt
+  onSave: (title: string, content: string) => void
+}
+
+function PromptDialog({ open, onOpenChange, prompt, onSave }: PromptDialogProps) {
+  const [title, setTitle] = useState(prompt?.title || '')
+  const [content, setContent] = useState(prompt?.content || '')
+
+  const handleSave = () => {
+    if (title.trim() && content.trim()) {
+      onSave(title.trim(), content.trim())
+      setTitle('')
+      setContent('')
+      onOpenChange(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[525px]">
+        <DialogHeader>
+          <DialogTitle>{prompt ? 'Edit Prompt' : 'Add New Prompt'}</DialogTitle>
+          <DialogDescription>
+            {prompt ? 'Update your prompt template' : 'Create a new prompt template'}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid gap-2">
+            <Label htmlFor="title">Title</Label>
+            <Input
+              id="title"
+              value={title}
+              onChange={e => setTitle(e.target.value)}
+              placeholder="e.g., Summarize page"
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="content">Prompt</Label>
+            <Textarea
+              id="content"
+              value={content}
+              onChange={e => setContent(e.target.value)}
+              placeholder="Enter your prompt template..."
+              className="min-h-[150px]"
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={!title.trim() || !content.trim()}>
+            {prompt ? 'Update' : 'Add'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default function PromptLibrary() {
+  const prompts = useChatStore(state => state.settings.data?.prompts || [])
+  const addPrompt = useChatStore(state => state.addPrompt)
+  const updatePrompt = useChatStore(state => state.updatePrompt)
+  const deletePrompt = useChatStore(state => state.deletePrompt)
+
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editingPrompt, setEditingPrompt] = useState<Prompt | undefined>()
+
+  const handleAddPrompt = () => {
+    setEditingPrompt(undefined)
+    setDialogOpen(true)
+  }
+
+  const handleEditPrompt = (prompt: Prompt) => {
+    setEditingPrompt(prompt)
+    setDialogOpen(true)
+  }
+
+  const handleSave = (title: string, content: string) => {
+    if (editingPrompt) {
+      updatePrompt(editingPrompt.id, title, content)
+    } else {
+      addPrompt(title, content)
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle>Prompt Library</CardTitle>
+            <CardDescription>Create and manage reusable prompt templates</CardDescription>
+          </div>
+          <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+            <DialogTrigger asChild>
+              <Button onClick={handleAddPrompt} size="sm">
+                <Plus className="size-4 mr-2" />
+                Add Prompt
+              </Button>
+            </DialogTrigger>
+            <PromptDialog
+              open={dialogOpen}
+              onOpenChange={setDialogOpen}
+              prompt={editingPrompt}
+              onSave={handleSave}
+            />
+          </Dialog>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {prompts.length === 0 ? (
+          <div className="text-center py-8 text-muted-foreground">
+            No prompts yet. Click "Add Prompt" to create your first template.
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {prompts.map(prompt => (
+              <div
+                key={prompt.id}
+                className="flex items-start justify-between p-3 border rounded-lg hover:bg-accent/50 transition-colors"
+              >
+                <div className="flex-1 min-w-0">
+                  <h4 className="font-medium text-sm">{prompt.title}</h4>
+                  <p className="text-sm text-muted-foreground mt-1 line-clamp-2">
+                    {prompt.content}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2 ml-4">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleEditPrompt(prompt)}
+                    className="size-8"
+                  >
+                    <Pencil className="size-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => deletePrompt(prompt.id)}
+                    className="size-8 text-destructive hover:text-destructive"
+                  >
+                    <Trash2 className="size-4" />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/SettingsPage/SettingsPage.tsx
+++ b/src/components/SettingsPage/SettingsPage.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import PromptLibrary from '@/components/PromptLibrary/PromptLibrary'
 import useChatStore from '@/stores/useChatStore'
 
 export default function SettingsPage() {
@@ -30,7 +31,7 @@ export default function SettingsPage() {
 
   return (
     <div className="min-h-screen bg-sidebar p-8">
-      <div className="max-w-2xl mx-auto">
+      <div className="max-w-2xl mx-auto space-y-6">
         <Card>
           <CardHeader>
             <CardTitle className="text-3xl">{'Chat Connect Settings'}</CardTitle>
@@ -74,6 +75,7 @@ export default function SettingsPage() {
             </Button>
           </CardFooter>
         </Card>
+        <PromptLibrary />
         {(settings.error || settingsForm.saveError) && (
           <Alert className="mt-4" variant="destructive">
             <AlertCircleIcon />

--- a/src/stores/slices/settingsSlice.ts
+++ b/src/stores/slices/settingsSlice.ts
@@ -15,6 +15,7 @@ const defaultSettings: Settings = {
   openAIToken: '',
   model: AIModel.OpenAI_GPT_5,
   autoExecuteTools: false,
+  prompts: [],
 }
 
 export const createSettingsSlice: StateCreator<ChatStore, [], [], SettingsSlice> = (set, get) => ({
@@ -119,6 +120,29 @@ export const createSettingsSlice: StateCreator<ChatStore, [], [], SettingsSlice>
     } catch (error) {
       set({ settingsForm: { ...settingsForm, saving: false, saveError: getStringError(error) } })
     }
+  },
+  addPrompt: (title: string, content: string) => {
+    const { settings } = get()
+    const newPrompt = {
+      id: crypto.randomUUID(),
+      title,
+      content,
+      createdAt: new Date().toISOString(),
+    }
+    const prompts = [...(settings.data?.prompts || []), newPrompt]
+    get().updateSettings({ prompts })
+  },
+  updatePrompt: (id: string, title: string, content: string) => {
+    const { settings } = get()
+    const prompts = settings.data?.prompts.map(p =>
+      p.id === id ? { ...p, title, content } : p
+    ) || []
+    get().updateSettings({ prompts })
+  },
+  deletePrompt: (id: string) => {
+    const { settings } = get()
+    const prompts = settings.data?.prompts.filter(p => p.id !== id) || []
+    get().updateSettings({ prompts })
   },
   assistant: null,
 })

--- a/src/stores/useChatStore.types.ts
+++ b/src/stores/useChatStore.types.ts
@@ -2,7 +2,7 @@ import type { IAssistant } from '@/services/assistant'
 import type { ChatView, Message, Thread } from '@/types/chat.types'
 import type { FunctionCallResult } from '@/types/tool.types'
 import type { ProviderMessageEvent } from '@/types/provider.types'
-import { Settings } from '@/types/settings.types'
+import { Settings, Prompt } from '@/types/settings.types'
 
 export type ThreadSlice = {
   threadId: string
@@ -36,6 +36,9 @@ export type SettingsSlice = {
   }
   updateSettingsForm: (settings: Partial<Settings>) => void
   saveSettingsForm: () => Promise<void>
+  addPrompt: (title: string, content: string) => void
+  updatePrompt: (id: string, title: string, content: string) => void
+  deletePrompt: (id: string) => void
   assistant: IAssistant | null
 }
 

--- a/src/types/settings.types.ts
+++ b/src/types/settings.types.ts
@@ -1,7 +1,15 @@
 import { AIModel } from './provider.types'
 
+export type Prompt = {
+  id: string
+  title: string
+  content: string
+  createdAt: string
+}
+
 export type Settings = {
   openAIToken: string
   model: AIModel
   autoExecuteTools: boolean
+  prompts: Prompt[]
 }


### PR DESCRIPTION
## Summary
- Implement complete prompt library system for creating and managing reusable prompt templates
- Add Prompt type definition with id, title, content, and createdAt fields
- Integrate prompts into Settings with automatic browser storage persistence
- Create PromptLibrary component with full CRUD interface in settings page
- Add prompt selector button in ChatInput with popover UI for quick access
- Install required Radix UI components (dialog and popover)

## Test plan
- [ ] Open settings page and verify PromptLibrary section appears
- [ ] Create a new prompt template with a title and content
- [ ] Edit an existing prompt and verify changes persist
- [ ] Delete a prompt and confirm it's removed
- [ ] Navigate to chat and verify book icon appears when prompts exist
- [ ] Click book icon and select a prompt to fill the input field
- [ ] Verify all prompts persist after page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)